### PR TITLE
feat(security): works without adding user to input group

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ physical keyboard
 cargo fmt --check
 cargo test
 cargo build --release
-systemctl --user restart lay-daemon
+sudo systemctl restart lay-daemon
 ```
 
 For diagnostics:
@@ -41,5 +41,5 @@ For diagnostics:
 ```bash
 lay-daemon --debug-log
 LAY_DEBUG_LOG=1 lay-daemon
-journalctl --user -u lay-daemon -f
+sudo journalctl -u lay-daemon -f
 ```

--- a/HOW_IT_WORKS.md
+++ b/HOW_IT_WORKS.md
@@ -111,9 +111,12 @@ Desktop-адаптеры:
 способ читать все нажатия — `/dev/input/event*` (evdev), напрямую
 из ядра, до любых Wayland-протоколов.
 
-Требует членства в группе `input`:
+Требует членства в группе `input`. В новой архитектуре daemon работает как системный сервис
+с `SupplementaryGroups=input` — только процесс daemon имеет доступ к `/dev/input`,
+а пользователь не добавляется в группу `input`.
 ```bash
-sudo usermod -aG input $USER
+# Доступ к /dev/input — только для процесса daemon (SupplementaryGroups=input)
+# Пользователь НЕ добавляется в группу input
 ```
 
 ### Почему uinput, а не wtype/xdotool

--- a/README.md
+++ b/README.md
@@ -665,7 +665,7 @@ gnome-extensions enable lay@radislabus-star.github.io
 - GNOME Shell 45, 46, 47 или 50 либо KDE Plasma 6
 - Wayland-сессия для GNOME/KDE или X11-сессия для X11 backend
 - Rust 1.75+
-- доступ к `/dev/input` через группу `input`
+- доступ к `/dev/input` через SupplementaryGroups=input (только процесс daemon)
 - доступный `/dev/uinput` для обратной печати
 - IBus и `python3-gi`, если включаешь экспериментальный `text_backend = "ime"`
 
@@ -676,9 +676,9 @@ X11 backend использует pure-Rust `x11rb` для прямых XKB-за�
 XKB недоступен, daemon пробует старые fallback tools: `xkb-switch`,
 `xkblayout-state` и `setxkbmap`.
 
-Установщик может добавить текущего пользователя в группу `input` и поставить
-udev-правило для `/dev/uinput`, но группа начинает работать только после нового
-входа в систему.
+Демон работает как системный сервис с `SupplementaryGroups=input` — только процесс daemon
+имеет доступ к `/dev/input`. Пользователь НЕ добавляется в группу `input`. udev-правило
+настраивает `/dev/uinput` для группы input.
 
 ### CLI
 
@@ -1088,8 +1088,8 @@ cd ~/projects/lay
 bash install.sh
 ```
 
-After installation, log out and log back in so the `input` group, `/dev/uinput`
-permissions, and GNOME extension are picked up.
+After installation, log out and log back in so the GNOME extension and
+`/dev/uinput` permissions are picked up.
 
 Update an existing git install:
 

--- a/dev-reload.sh
+++ b/dev-reload.sh
@@ -29,5 +29,5 @@ else
 fi
 
 sleep 2
-systemctl --user restart lay-daemon
+sudo systemctl restart lay-daemon
 echo "✓ готово"

--- a/extension/lay@radislabus-star.github.io/lay-impl.js
+++ b/extension/lay@radislabus-star.github.io/lay-impl.js
@@ -304,7 +304,7 @@ function stopDaemon() {
     daemonCommand('stop');
 }
 function daemonCommand(action) {
-    try { Gio.Subprocess.new(['systemctl','--user',action,'lay-daemon'], Gio.SubprocessFlags.NONE); } catch(e) {}
+    try { Gio.Subprocess.new(['systemctl',action,'lay-daemon'], Gio.SubprocessFlags.NONE); } catch(e) {}
 }
 function firstExistingCommand(names) {
     for (const name of names)
@@ -1652,7 +1652,7 @@ class LayIndicator extends PanelMenu.Button {
     _refreshStatus() {
         try {
             const p = Gio.Subprocess.new(
-                ['systemctl','--user','is-active','lay-daemon'],
+                ['systemctl','is-active','lay-daemon'],
                 Gio.SubprocessFlags.STDOUT_PIPE);
             p.communicate_utf8_async(null, null, (proc, res) => {
                 try {

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # install.sh — собрать и установить lay + lay-daemon + GNOME extension
+# Безопасный режим: daemon работает от текущего пользователя с SupplementaryGroups=input,
+# основной пользователь НЕ добавляется в группу input.
 set -eu
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -118,16 +120,6 @@ fi
 echo "✓ $(rustc --version)"
 
 echo ""
-echo "=== группа input (нужна для evdev) ==="
-if id -nG "$USER" | grep -qw input; then
-    echo "✓ уже в группе input"
-else
-    echo "→ добавляю $USER в группу input..."
-    sudo usermod -aG input "$USER"
-    echo "⚠ нужен перелогин чтобы группа применилась"
-fi
-
-echo ""
 echo "=== uinput permissions (нужно для обратной печати) ==="
 UINPUT_RULE='/etc/udev/rules.d/99-lay-uinput.rules'
 UINPUT_RULE_TEXT='KERNEL=="uinput", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput"'
@@ -227,14 +219,39 @@ echo "✓ IBus component установлен: ~/.local/share/ibus/component/lay
 echo "  Экспериментальный режим: выбрать Lay IME RU/Lay IME US в IBus и поставить text_backend=ime"
 
 echo ""
-echo "=== systemd unit для lay-daemon ==="
-mkdir -p ~/.config/systemd/user
-cp "$DIR/systemd/lay-daemon.service" ~/.config/systemd/user/lay-daemon.service
-cp "$DIR/systemd/lay-kde-tray.service" ~/.config/systemd/user/lay-kde-tray.service
-cp "$DIR/systemd/lay-host-vm-guard.service" ~/.config/systemd/user/lay-host-vm-guard.service
+echo "=== systemd unit для lay-daemon (system, SupplementaryGroups=input) ==="
+
+# Директории для daemon
+mkdir -p "$HOME/.config/lay" "$HOME/.cache/lay" "$HOME/.local/share/lay"
+
+# Systemd сервис — копируем в системную директорию
+sudo mkdir -p /etc/systemd/system
+sudo cp "$DIR/systemd/lay-daemon.service" /etc/systemd/system/lay-daemon.service
+
+# Дроп-ин с user-specific конфигурацией (генерируется динамически)
+sudo mkdir -p /etc/systemd/system/lay-daemon.service.d
+sudo tee /etc/systemd/system/lay-daemon.service.d/paths.conf > /dev/null <<EOF
+[Service]
+User=$USER
+Group=$USER
+ExecStart=$HOME/.local/bin/lay-daemon
+# Для диагностики: добавь --debug-log или -v. Вывод попадёт в journal и может содержать набранный текст.
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$UID/bus
+EOF
+
+# Удаление старого user-level сервиса если был
+rm -f "$HOME/.config/systemd/user/lay-daemon.service" 2>/dev/null || true
+
+sudo systemctl daemon-reload
+sudo systemctl enable lay-daemon.service
+echo "✓ lay-daemon.service установлен и включён (system, SupplementaryGroups=input)"
+
+# User-level сервисы (KDE tray, VM guard)
+mkdir -p "$HOME/.config/systemd/user"
+cp "$DIR/systemd/lay-kde-tray.service" "$HOME/.config/systemd/user/lay-kde-tray.service"
+cp "$DIR/systemd/lay-host-vm-guard.service" "$HOME/.config/systemd/user/lay-host-vm-guard.service"
 systemctl --user daemon-reload
-systemctl --user enable lay-daemon
-echo "✓ lay-daemon.service установлен и включён"
+
 if is_kde_available; then
     install_kde_autostart
     systemctl --user disable lay-kde-tray.service >/dev/null 2>&1 || true

--- a/scripts/lay-host-vm-guard.sh
+++ b/scripts/lay-host-vm-guard.sh
@@ -17,12 +17,12 @@ viewer_running() {
 }
 
 daemon_active() {
-    systemctl --user is-active --quiet lay-daemon.service
+    sudo systemctl is-active --quiet lay-daemon.service
 }
 
 pause_daemon() {
     if daemon_active; then
-        systemctl --user stop lay-daemon.service
+        sudo systemctl stop lay-daemon.service
         printf '%s\n' "paused-by-vm-guard" >"${state_file}"
         echo "lay-host-vm-guard: paused host lay-daemon"
     fi
@@ -30,7 +30,7 @@ pause_daemon() {
 
 resume_daemon() {
     if [ -f "${state_file}" ]; then
-        systemctl --user start lay-daemon.service
+        sudo systemctl start lay-daemon.service
         rm -f "${state_file}"
         echo "lay-host-vm-guard: resumed host lay-daemon"
     fi

--- a/systemd/lay-daemon.service
+++ b/systemd/lay-daemon.service
@@ -4,10 +4,14 @@ After=graphical-session.target
 
 [Service]
 Type=simple
-ExecStart=%h/.local/bin/lay-daemon
-# Для диагностики: добавь --debug-log или -v. Вывод попадёт в journal и может содержать набранный текст.
+SupplementaryGroups=input
+# Пользователь, группа и ExecStart устанавливаются в дроп-ине.
 Restart=on-failure
 RestartSec=3
+
+# Устройства ввода — разрешаем
+BindReadOnlyPaths=/dev/input
+BindPaths=/dev/uinput
 
 [Install]
 WantedBy=default.target

--- a/update.sh
+++ b/update.sh
@@ -81,7 +81,7 @@ if command -v gnome-extensions >/dev/null 2>&1; then
         gnome-extensions enable lay@radislabus-star.github.io 2>/dev/null || true
     fi
 fi
-systemctl --user restart lay-daemon || true
+sudo systemctl restart lay-daemon || true
 if [ -f "$HOME/.config/autostart/lay-kde-tray.desktop" ]; then
     pkill -f "$HOME/.local/bin/lay-kde-tray" 2>/dev/null || true
     desktop_hint="${XDG_CURRENT_DESKTOP:-}:${XDG_SESSION_DESKTOP:-}:${DESKTOP_SESSION:-}"


### PR DESCRIPTION
Fix #19 

## Описание

Переход с user-level systemd сервиса на system-level с `SupplementaryGroups=input`.

## Проблема

Предыдущая архитектура добавляла основного пользователя в группу `input` для доступа к `/dev/input`. Это означало, что **любой** процесс от пользователя мог читать клавиатуру — потенциальный кейлоггер.

## Решение

- Daemon работает как системный сервис с `SupplementaryGroups=input` — только процесс daemon имеет доступ к `/dev/input`
- Пользователь НЕ добавляется в группу `input`
- Пользовательские настройки (User, Group, ExecStart, DBUS_SESSION_BUS_ADDRESS) передаются через дроп-ин файл, генерируемый install.sh
- Все команды управления daemon (`systemctl`) теперь используют `sudo systemctl` (system-level)

## Безопасность

- `/dev/input/event*` доступен только процессу daemon (через `SupplementaryGroups=input`)
- Другие процессы от пользователя не могут читать клавиатуру
- DBus session bus работает естественно (тот же UID)

## Ограничение

**Только один пользователь**. У сервиса захардкожен дроп-ин файл с именем полбзователя.

Возможно расширение через шаблонный сервис (`lay-daemon@.service`) — тогда каждый пользователь получает свой экземпляр daemon'а, но я решил не ввязываться.