### PR TITLE
fix(ascii): prevent LEM arbiter from overriding user-protected words

### DIFF
--- a/src/layout_autoswitch/ascii/word.rs
+++ b/src/layout_autoswitch/ascii/word.rs
@@ -1,3 +1,4 @@
+use crate::lexicon::is_user_protected_ascii_word;
 use crate::russian_lexicon::russian_tiny_dictionary;
 use crate::word_reader::split_word_punctuation;
 
@@ -21,6 +22,9 @@ pub(crate) fn correct_wrong_layout_ascii_word(token: &str) -> Option<String> {
 
     let (_, original_word, _) = split_word_punctuation(token);
     if original_word.is_empty() {
+        return None;
+    }
+    if is_user_protected_ascii_word(original_word) {
         return None;
     }
 
@@ -86,6 +90,9 @@ fn correct_wrong_layout_ascii_word_preserving_trailing_punctuation(token: &str) 
 
     let (_, original_word, _) = split_word_punctuation(core);
     if original_word.is_empty() {
+        return None;
+    }
+    if is_user_protected_ascii_word(original_word) {
         return None;
     }
     let normalized = ascii_to_russian_layout_candidate(core, false)?.replacement;


### PR DESCRIPTION
fix #27 